### PR TITLE
Improve Gradle config and remove unnecessary `OptIn` annotations

### DIFF
--- a/arrow-reflect-annotations/build.gradle.kts
+++ b/arrow-reflect-annotations/build.gradle.kts
@@ -1,16 +1,23 @@
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
-buildscript {
-  repositories {
-    gradlePluginPortal()
-    mavenCentral()
-  }
-}
-
 plugins {
   alias(libs.plugins.kotlin.jvm)
   //  alias(libs.plugins.arrowGradleConfig.kotlin)
   alias(libs.plugins.arrowGradleConfig.publish)
+}
+
+kotlin {
+  sourceSets.all {
+    languageSettings {
+      optIn("kotlin.RequiresOptIn")
+      optIn("org.jetbrains.kotlin.compiler.plugin.ExperimentalCompilerApi")
+      optIn("org.jetbrains.kotlin.diagnostics.InternalDiagnosticFactoryMethod")
+      optIn("org.jetbrains.kotlin.ir.ObsoleteDescriptorBasedAPI")
+      optIn("org.jetbrains.kotlin.fir.PrivateForInline")
+      optIn("org.jetbrains.kotlin.fir.resolve.dfa.DfaInternals")
+      optIn("org.jetbrains.kotlin.fir.symbols.SymbolInternals")
+    }
+  }
 }
 
 tasks {
@@ -18,12 +25,12 @@ tasks {
   dokkaHtml { enabled = false }
   dokkaJavadoc { enabled = false }
   dokkaJekyll { enabled = false }
-}
 
-tasks.withType<KotlinCompile>().configureEach {
-  compilerOptions {
-    useK2.set(true)
-    freeCompilerArgs.set(listOf("-Xcontext-receivers"))
+  withType<KotlinCompile>().configureEach {
+    compilerOptions {
+      useK2.set(true)
+      freeCompilerArgs.add("-Xcontext-receivers")
+    }
   }
 }
 
@@ -32,7 +39,6 @@ kotlin {
     languageVersion.set(JavaLanguageVersion.of(8)) // "8"
   }
 }
-
 
 sourceSets {
   main {

--- a/arrow-reflect-annotations/src/main/kotlin/arrow/meta/Meta.kt
+++ b/arrow-reflect-annotations/src/main/kotlin/arrow/meta/Meta.kt
@@ -35,7 +35,6 @@ annotation class Meta {
       return newCall
     }
 
-    @OptIn(SymbolInternals::class)
     private fun isDecorated(newElement: FirFunctionCall): Boolean =
       newElement.toResolvedCallableSymbol()?.fir?.annotations?.hasAnnotation(
         ClassId.topLevel(
@@ -106,11 +105,9 @@ annotation class Meta {
 
       interface Functions : Members {
 
-        @OptIn(SymbolInternals::class)
         fun FirMetaContext.functions(firClass: FirClassSymbol<*>): Set<Name> =
           newFunctions(firClass.fir).keys.map { Name.identifier(it) }.toSet()
 
-        @OptIn(SymbolInternals::class)
         fun FirMetaContext.functions(callableId: CallableId, context: MemberGenerationContext): List<FirFunction> {
           val firClass = context.owner.fir
           return newFunctions(firClass).values.map { it().function }
@@ -511,4 +508,3 @@ annotation class Meta {
   }
 
 }
-

--- a/arrow-reflect-annotations/src/main/kotlin/arrow/meta/MetaContext.kt
+++ b/arrow-reflect-annotations/src/main/kotlin/arrow/meta/MetaContext.kt
@@ -61,7 +61,6 @@ abstract class FirMetaContext(
 
   abstract val scopeDeclarations: List<FirDeclaration>
 
-  @OptIn(SymbolInternals::class)
   fun propertiesOf(firClass: FirClass, f: (FirValueParameter) -> String): String =
     +firClass.primaryConstructorIfAny(session)?.fir?.valueParameters.orEmpty().filter { it.isVal }.map {
       f(it)
@@ -146,8 +145,6 @@ class FirMetaMemberGenerationContext(
   val memberGenerationContext: MemberGenerationContext?,
 ) : FirMetaContext(session, templateCompiler) {
 
-  @OptIn(SymbolInternals::class)
   override val scopeDeclarations: List<FirDeclaration>
     get() = listOfNotNull(memberGenerationContext?.owner?.fir)
 }
-

--- a/arrow-reflect-annotations/src/main/kotlin/arrow/meta/TemplateCompiler.kt
+++ b/arrow-reflect-annotations/src/main/kotlin/arrow/meta/TemplateCompiler.kt
@@ -338,22 +338,22 @@ fun FirResolvePhase.createCompilerProcessorByPhase(
   }
 }
 
-@OptIn(AdapterForResolveProcessor::class)
 class FirBodyResolveProcessor(
   session: FirSession,
   scopeSession: ScopeSession,
   scopeDeclarations: List<FirDeclaration>
 ) : FirTransformerBasedResolveProcessor(session, scopeSession, FirResolvePhase.BODY_RESOLVE) {
+
   override val transformer = FirBodyResolveTransformerAdapter(session, scopeSession, scopeDeclarations)
 }
 
-@AdapterForResolveProcessor
+
 class FirBodyResolveTransformerAdapter(
   session: FirSession,
   scopeSession: ScopeSession,
   scopeDeclarations: List<FirDeclaration>
 ) : FirTransformer<Any?>() {
-  @OptIn(PrivateForInline::class)
+
   private val transformer = FirBodyResolveTransformer(
     session,
     phase = FirResolvePhase.BODY_RESOLVE,

--- a/arrow-reflect-annotations/src/main/kotlin/arrow/meta/samples/pure/LocalCallGraph.kt
+++ b/arrow-reflect-annotations/src/main/kotlin/arrow/meta/samples/pure/LocalCallGraph.kt
@@ -27,8 +27,6 @@ internal fun FirMetaCheckerContext.createLocalCallGraph(
   } else existingReference
 }
 
-
-@OptIn(SymbolInternals::class)
 private fun FirSimpleFunction.calledMethods(): Map<FirFunctionCall, FirSimpleFunction> {
   val calledMethods = mutableMapOf<FirFunctionCall, FirSimpleFunction>()
   val visitor = object : FirVisitorVoid() {

--- a/arrow-reflect-compiler-plugin/build.gradle.kts
+++ b/arrow-reflect-compiler-plugin/build.gradle.kts
@@ -10,13 +10,13 @@ kotlin {
   sourceSets.all {
     languageSettings {
       optIn("kotlin.RequiresOptIn")
-      optIn("org.jetbrains.kotlin.fir.symbols.SymbolInternals")
-      optIn("org.jetbrains.kotlin.fir.resolve.dfa.DfaInternals")
-      optIn("org.jetbrains.kotlin.fir.resolve.dfa.DfaInternals")
-      optIn("org.jetbrains.kotlin.fir.PrivateForInline")
+      optIn("org.jetbrains.kotlin.compiler.plugin.ExperimentalCompilerApi")
       optIn("org.jetbrains.kotlin.diagnostics.InternalDiagnosticFactoryMethod")
       optIn("org.jetbrains.kotlin.ir.ObsoleteDescriptorBasedAPI")
-      optIn("org.jetbrains.kotlin.compiler.plugin.ExperimentalCompilerApi")
+      optIn("org.jetbrains.kotlin.fir.PrivateForInline")
+      optIn("org.jetbrains.kotlin.fir.resolve.dfa.DfaInternals")
+      optIn("org.jetbrains.kotlin.fir.resolve.transformers.AdapterForResolveProcessor")
+      optIn("org.jetbrains.kotlin.fir.symbols.SymbolInternals")
     }
   }
 }
@@ -62,7 +62,7 @@ dependencies {
 tasks.withType<KotlinCompile>().configureEach {
   compilerOptions {
     useK2.set(true)
-    freeCompilerArgs.set(listOf("-Xcontext-receivers"))
+    freeCompilerArgs.add("-Xcontext-receivers")
   }
 }
 

--- a/docs/build.gradle.kts
+++ b/docs/build.gradle.kts
@@ -1,3 +1,5 @@
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
+
 plugins {
   alias(libs.plugins.kotlin.jvm)
   alias(libs.plugins.arrowGradleConfig.kotlin)
@@ -13,7 +15,9 @@ tasks {
     delete("$rootDir/docs/docs/apidocs")
   }
 
-  compileKotlin {
-    kotlinOptions.freeCompilerArgs += listOf("-Xskip-runtime-version-check")
+  withType<KotlinCompile>().configureEach {
+    compilerOptions {
+      freeCompilerArgs.add("-Xskip-runtime-version-check")
+    }
   }
 }

--- a/sandbox/build.gradle.kts
+++ b/sandbox/build.gradle.kts
@@ -8,15 +8,14 @@ plugins {
   application
 }
 
-application { mainClass.set("example.SampleKt") }
+application {
+  mainClass.set("example.SampleKt")
+}
 
 tasks.withType<KotlinCompile>().configureEach {
   compilerOptions {
     useK2.set(true)
-    freeCompilerArgs.addAll(
-      "-Xcontext-receivers",
-      // "-Xplugin=$rootDir/arrow-inject-compiler-plugin/build/libs/arrow-reflect-compiler-plugin-0.1.0.jar"
-    )
+    freeCompilerArgs.add("-Xcontext-receivers")
   }
 }
 

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -16,6 +16,7 @@ pluginManagement {
 dependencyResolutionManagement {
   repositories {
     mavenCentral()
+    gradlePluginPortal()
     maven(url = "https://oss.sonatype.org/content/repositories/snapshots")
     maven(url = "https://maven.pkg.jetbrains.space/kotlin/p/kotlin/bootstrap")
     mavenLocal {


### PR DESCRIPTION
I extracted all `OptIn` annotations we are using right so we don't need to annotate any classes/functions/files anymore.