### PR TITLE
Macro API with Context Parameters

### DIFF
--- a/arrow-reflect-annotations/build.gradle.kts
+++ b/arrow-reflect-annotations/build.gradle.kts
@@ -1,3 +1,6 @@
+import org.gradle.kotlin.dsl.withType
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
+
 plugins {
   alias(libs.plugins.kotlin.jvm)
   //  alias(libs.plugins.arrowGradleConfig.kotlin)
@@ -55,6 +58,12 @@ dependencies {
   testImplementation("junit:junit:4.13.2")
   testImplementation(platform("org.junit:junit-bom:5.13.4"))
   testImplementation("org.junit.jupiter:junit-jupiter")
+}
+
+tasks.withType<KotlinCompile>().configureEach {
+  compilerOptions {
+    freeCompilerArgs.add("-Xcontext-parameters")
+  }
 }
 
 tasks.test {

--- a/arrow-reflect-annotations/src/main/kotlin/arrow/meta/macro/compilation/DiagnosticsCompilation.kt
+++ b/arrow-reflect-annotations/src/main/kotlin/arrow/meta/macro/compilation/DiagnosticsCompilation.kt
@@ -29,12 +29,17 @@ open class DiagnosticsContext(
   private val checkerContext: CheckerContext
 ) {
 
-  fun FirElement.report(factory: KtDiagnosticFactory1<String>, msg: String) {
+  fun report(element: FirElement, factory: KtDiagnosticFactory1<String>, msg: String) {
     diagnosticReporter.reportOn(
-      source,
+      element.source,
       factory,
       msg,
       checkerContext
     )
   }
+}
+
+context(context: DiagnosticsContext)
+fun FirElement.report(factory: KtDiagnosticFactory1<String>, msg: String) {
+  context.report(element = this, factory = factory, msg = msg)
 }

--- a/arrow-reflect-annotations/src/main/kotlin/arrow/meta/macro/compilation/MacroContext.kt
+++ b/arrow-reflect-annotations/src/main/kotlin/arrow/meta/macro/compilation/MacroContext.kt
@@ -1,69 +1,37 @@
 package arrow.meta.module.impl.arrow.meta.macro.compilation
 
+import arrow.meta.module.impl.arrow.meta.macro.compilation.transformclassfactory.TransformClassFactory
 import org.jetbrains.kotlin.fir.FirElement
-import org.jetbrains.kotlin.fir.FirSession
-import org.jetbrains.kotlin.fir.declarations.DirectDeclarationsAccess
 import org.jetbrains.kotlin.fir.declarations.FirClass
-import org.jetbrains.kotlin.fir.declarations.FirValueParameter
-import org.jetbrains.kotlin.fir.declarations.impl.FirPrimaryConstructor
-import org.jetbrains.kotlin.fir.declarations.primaryConstructorIfAny
-import org.jetbrains.kotlin.fir.symbols.SymbolInternals
-import org.jetbrains.kotlin.fir.types.FirTypeRef
-import org.jetbrains.kotlin.fir.types.coneType
-import org.jetbrains.kotlin.fir.types.renderReadableWithFqNames
-import org.jetbrains.kotlin.name.Name
-import org.jetbrains.kotlin.text
-import org.jetbrains.kotlin.utils.addToStdlib.firstIsInstanceOrNull
-import kotlin.collections.filter
-import kotlin.collections.map
-import kotlin.collections.orEmpty
 
-interface MacroContext {
+interface MacroContext
 
-  fun diagnostics(scope: DiagnosticsContext.() -> Unit): DiagnosticsCompilation {
-    return object : DiagnosticsCompilation {
-      override fun runCompilation(context: DiagnosticsContext) {
-        context.scope()
-      }
+context(_: MacroContext)
+fun diagnostics(scope: DiagnosticsContext.() -> Unit): DiagnosticsCompilation {
+  return object : DiagnosticsCompilation {
+    override fun runCompilation(context: DiagnosticsContext) {
+      context.scope()
     }
   }
+}
 
-  fun <T : FirElement> transform(scope: TransformContext.() -> T): TransformCompilation<T> {
-    return object : TransformCompilation<T> {
-      override fun transform(context: TransformContext): T {
-        return context.scope()
-      }
+context(_: MacroContext)
+fun <T : FirElement> transform(scope: TransformContext.() -> T): TransformCompilation<T> {
+  return object : TransformCompilation<T> {
+    override fun transform(context: TransformContext): T {
+      return context.scope()
     }
   }
+}
 
-  fun FirClass.transform(scope: TransformClassFactory.() -> Unit): TransformClassCompilation {
-    return object : TransformClassCompilation {
-      override fun transform(context: TransformClassContext): TransformClassFactory {
-        return TransformClassFactory(
-          firClass = this@transform,
-          context = context
-        ).also { scope(it) }
-      }
+context(_: MacroContext)
+fun FirClass.transform(scope: TransformClassFactory.() -> Unit): TransformClassCompilation {
+  return object : TransformClassCompilation {
+    override fun transform(context: TransformClassContext): TransformClassFactory {
+      return TransformClassFactory(
+        firClass = this@transform,
+        context = context
+      ).also { scope(it) }
     }
   }
-
-  @OptIn(SymbolInternals::class, DirectDeclarationsAccess::class)
-  fun propertiesOf(session: FirSession, firClass: FirClass, f: (FirValueParameter) -> String): String =
-    +firClass.declarations.firstIsInstanceOrNull<FirPrimaryConstructor>()?.valueParameters.orEmpty().filter { it.isVal }.map {
-      f(it)
-    }
-
-  operator fun List<String>.unaryPlus(): String =
-    joinToString()
-
-  operator fun Sequence<String>.unaryPlus(): String =
-    joinToString()
-
-  operator fun Name?.unaryPlus(): String =
-    this?.asString() ?: ""
-
-  operator fun FirElement.unaryPlus(): String =
-    (this as? FirTypeRef)?.coneType?.renderReadableWithFqNames()?.replace("/", ".")
-      ?: source?.text?.toString()
-      ?: error("$this has no source psi text element")
 }

--- a/arrow-reflect-annotations/src/main/kotlin/arrow/meta/macro/compilation/MacroContextBuiltIns.kt
+++ b/arrow-reflect-annotations/src/main/kotlin/arrow/meta/macro/compilation/MacroContextBuiltIns.kt
@@ -1,0 +1,51 @@
+package arrow.meta.module.impl.arrow.meta.macro.compilation
+
+import arrow.meta.module.impl.arrow.meta.quote.Kotlin
+import org.jetbrains.kotlin.fir.FirElement
+import org.jetbrains.kotlin.fir.FirSession
+import org.jetbrains.kotlin.fir.declarations.DirectDeclarationsAccess
+import org.jetbrains.kotlin.fir.declarations.FirClass
+import org.jetbrains.kotlin.fir.declarations.FirDeclaration
+import org.jetbrains.kotlin.fir.declarations.FirSimpleFunction
+import org.jetbrains.kotlin.fir.declarations.FirValueParameter
+import org.jetbrains.kotlin.fir.declarations.impl.FirPrimaryConstructor
+import org.jetbrains.kotlin.fir.symbols.SymbolInternals
+import org.jetbrains.kotlin.fir.types.FirTypeRef
+import org.jetbrains.kotlin.fir.types.coneType
+import org.jetbrains.kotlin.fir.types.renderReadableWithFqNames
+import org.jetbrains.kotlin.name.Name
+import org.jetbrains.kotlin.text
+import org.jetbrains.kotlin.utils.addToStdlib.firstIsInstanceOrNull
+import kotlin.collections.filter
+import kotlin.collections.map
+import kotlin.collections.orEmpty
+
+@OptIn(SymbolInternals::class, DirectDeclarationsAccess::class)
+context(_: MacroContext)
+fun FirClass.properties(f: (FirValueParameter) -> String): String =
+  +declarations.firstIsInstanceOrNull<FirPrimaryConstructor>()?.valueParameters.orEmpty().filter { it.isVal }.map {
+    f(it)
+  }
+
+context(_: MacroContext)
+operator fun List<String>.unaryPlus(): String =
+  joinToString()
+
+context(_: MacroContext)
+operator fun Sequence<String>.unaryPlus(): String =
+  joinToString()
+
+context(_: MacroContext)
+operator fun Name?.unaryPlus(): String =
+  this?.asString() ?: ""
+
+context(_: MacroContext)
+operator fun FirElement.unaryPlus(): String =
+  (this as? FirTypeRef)?.coneType?.renderReadableWithFqNames()?.replace("/", ".")
+    ?: source?.text?.toString()
+    ?: error("$this has no source psi text element")
+
+context(_: MacroContext)
+fun String.function(session: FirSession, scope: List<FirDeclaration>): FirSimpleFunction? {
+  return Kotlin(session = session, scope = scope, code = { this }).firstIsInstanceOrNull()
+}

--- a/arrow-reflect-annotations/src/main/kotlin/arrow/meta/macro/compilation/MacroContextBuiltIns.kt
+++ b/arrow-reflect-annotations/src/main/kotlin/arrow/meta/macro/compilation/MacroContextBuiltIns.kt
@@ -6,6 +6,7 @@ import org.jetbrains.kotlin.fir.FirSession
 import org.jetbrains.kotlin.fir.declarations.DirectDeclarationsAccess
 import org.jetbrains.kotlin.fir.declarations.FirClass
 import org.jetbrains.kotlin.fir.declarations.FirDeclaration
+import org.jetbrains.kotlin.fir.declarations.FirProperty
 import org.jetbrains.kotlin.fir.declarations.FirSimpleFunction
 import org.jetbrains.kotlin.fir.declarations.FirValueParameter
 import org.jetbrains.kotlin.fir.declarations.impl.FirPrimaryConstructor
@@ -47,5 +48,10 @@ operator fun FirElement.unaryPlus(): String =
 
 context(_: MacroContext)
 fun String.function(session: FirSession, scope: List<FirDeclaration>): FirSimpleFunction? {
+  return Kotlin(session = session, scope = scope, code = { this }).firstIsInstanceOrNull()
+}
+
+context(_: MacroContext)
+fun String.property(session: FirSession, scope: List<FirDeclaration>): FirProperty? {
   return Kotlin(session = session, scope = scope, code = { this }).firstIsInstanceOrNull()
 }

--- a/arrow-reflect-annotations/src/main/kotlin/arrow/meta/macro/compilation/TransformClassCompilation.kt
+++ b/arrow-reflect-annotations/src/main/kotlin/arrow/meta/macro/compilation/TransformClassCompilation.kt
@@ -1,11 +1,10 @@
 package arrow.meta.module.impl.arrow.meta.macro.compilation
 
+import arrow.meta.module.impl.arrow.meta.macro.compilation.transformclassfactory.TransformClassFactory
 import arrow.meta.module.impl.arrow.meta.quote.Kotlin
 import org.jetbrains.kotlin.fir.FirSession
 import org.jetbrains.kotlin.fir.declarations.FirClass
 import org.jetbrains.kotlin.fir.declarations.FirDeclaration
-import org.jetbrains.kotlin.fir.declarations.FirSimpleFunction
-import org.jetbrains.kotlin.utils.addToStdlib.firstIsInstanceOrNull
 
 data class TransformClassContext(
   val session: FirSession,
@@ -20,35 +19,4 @@ data class TransformClassContext(
 interface TransformClassCompilation : MacroCompilation {
 
   fun transform(context: TransformClassContext): TransformClassFactory
-}
-
-class TransformClassFactory(
-  val firClass: FirClass,
-  private val context: TransformClassContext
-) : MacroCompilation {
-
-  private val states: MutableList<TransformClassState> = mutableListOf()
-
-  fun function(build: TransformClassContext.() -> String) {
-    val code = context.Kotlin(scope = firClass) { context.build().trimIndent() }
-    val function = code.firstIsInstanceOrNull<FirSimpleFunction>() ?: return
-    states.add(
-      TransformClassState.Function(
-        firFile = code,
-        firClass = firClass,
-        firSimpleFunction = function
-      )
-    )
-  }
-
-  fun states(): List<TransformClassState> = states
-}
-
-sealed interface TransformClassState {
-
-  data class Function(
-    val firFile: Kotlin,
-    val firClass: FirClass,
-    val firSimpleFunction: FirSimpleFunction
-  ) : TransformClassState
 }

--- a/arrow-reflect-annotations/src/main/kotlin/arrow/meta/macro/compilation/transformclassfactory/TransformClassFactory.kt
+++ b/arrow-reflect-annotations/src/main/kotlin/arrow/meta/macro/compilation/transformclassfactory/TransformClassFactory.kt
@@ -1,0 +1,33 @@
+package arrow.meta.module.impl.arrow.meta.macro.compilation.transformclassfactory
+
+import arrow.meta.module.impl.arrow.meta.macro.compilation.TransformClassContext
+import org.jetbrains.kotlin.fir.declarations.FirClass
+import org.jetbrains.kotlin.fir.declarations.FirSimpleFunction
+
+class TransformClassFactory(
+  val firClass: FirClass,
+  val context: TransformClassContext
+) {
+
+  private val states: MutableList<TransformClassState> = mutableListOf()
+
+  fun FirSimpleFunction?.create() {
+    if (this == null) return
+    states.add(
+      TransformClassState.Function(
+        context = firClass,
+        firSimpleFunction = this
+      )
+    )
+  }
+
+  fun states(): List<TransformClassState> = states
+}
+
+sealed interface TransformClassState {
+
+  data class Function(
+    val context: FirClass,
+    val firSimpleFunction: FirSimpleFunction
+  ) : TransformClassState
+}

--- a/arrow-reflect-annotations/src/main/kotlin/arrow/meta/macro/compilation/transformclassfactory/TransformClassFactory.kt
+++ b/arrow-reflect-annotations/src/main/kotlin/arrow/meta/macro/compilation/transformclassfactory/TransformClassFactory.kt
@@ -2,6 +2,7 @@ package arrow.meta.module.impl.arrow.meta.macro.compilation.transformclassfactor
 
 import arrow.meta.module.impl.arrow.meta.macro.compilation.TransformClassContext
 import org.jetbrains.kotlin.fir.declarations.FirClass
+import org.jetbrains.kotlin.fir.declarations.FirProperty
 import org.jetbrains.kotlin.fir.declarations.FirSimpleFunction
 
 class TransformClassFactory(
@@ -21,6 +22,16 @@ class TransformClassFactory(
     )
   }
 
+  fun FirProperty?.create() {
+    if (this == null) return
+    states.add(
+      TransformClassState.Property(
+        context = firClass,
+        firProperty = this
+      )
+    )
+  }
+
   fun states(): List<TransformClassState> = states
 }
 
@@ -29,5 +40,10 @@ sealed interface TransformClassState {
   data class Function(
     val context: FirClass,
     val firSimpleFunction: FirSimpleFunction
+  ) : TransformClassState
+
+  data class Property(
+    val context: FirClass,
+    val firProperty: FirProperty
   ) : TransformClassState
 }

--- a/arrow-reflect-annotations/src/main/kotlin/arrow/meta/macro/compilation/transformclassfactory/TransformClassFactoryBuiltIns.kt
+++ b/arrow-reflect-annotations/src/main/kotlin/arrow/meta/macro/compilation/transformclassfactory/TransformClassFactoryBuiltIns.kt
@@ -1,0 +1,8 @@
+package arrow.meta.module.impl.arrow.meta.macro.compilation.transformclassfactory
+
+import arrow.meta.module.impl.arrow.meta.macro.compilation.MacroContext
+import arrow.meta.module.impl.arrow.meta.macro.compilation.function
+import org.jetbrains.kotlin.fir.declarations.FirSimpleFunction
+
+context(_: MacroContext, factory: TransformClassFactory)
+fun String.function(): FirSimpleFunction? = function(session = factory.context.session, scope = listOf(factory.firClass))

--- a/arrow-reflect-annotations/src/main/kotlin/arrow/meta/macro/compilation/transformclassfactory/TransformClassFactoryBuiltIns.kt
+++ b/arrow-reflect-annotations/src/main/kotlin/arrow/meta/macro/compilation/transformclassfactory/TransformClassFactoryBuiltIns.kt
@@ -2,7 +2,12 @@ package arrow.meta.module.impl.arrow.meta.macro.compilation.transformclassfactor
 
 import arrow.meta.module.impl.arrow.meta.macro.compilation.MacroContext
 import arrow.meta.module.impl.arrow.meta.macro.compilation.function
+import arrow.meta.module.impl.arrow.meta.macro.compilation.property
+import org.jetbrains.kotlin.fir.declarations.FirProperty
 import org.jetbrains.kotlin.fir.declarations.FirSimpleFunction
 
 context(_: MacroContext, factory: TransformClassFactory)
 fun String.function(): FirSimpleFunction? = function(session = factory.context.session, scope = listOf(factory.firClass))
+
+context(_: MacroContext, factory: TransformClassFactory)
+fun String.property(): FirProperty? = property(session = factory.context.session, scope = listOf(factory.firClass))

--- a/arrow-reflect-annotations/src/main/kotlin/arrow/meta/module/macro/helloclasstransformer.kt
+++ b/arrow-reflect-annotations/src/main/kotlin/arrow/meta/module/macro/helloclasstransformer.kt
@@ -3,29 +3,29 @@ package arrow.meta.module.impl.arrow.meta.module.macro
 import arrow.meta.module.impl.arrow.meta.macro.Macro
 import arrow.meta.module.impl.arrow.meta.macro.compilation.MacroCompilation
 import arrow.meta.module.impl.arrow.meta.macro.compilation.MacroContext
+import arrow.meta.module.impl.arrow.meta.macro.compilation.transform
+import arrow.meta.module.impl.arrow.meta.macro.compilation.transformclassfactory.function
 import arrow.meta.samples.HelloClassTransform
 import org.jetbrains.kotlin.fir.declarations.FirClass
 
 @Macro(target = HelloClassTransform::class)
-fun MacroContext.hello(firClass: FirClass): MacroCompilation {
+context(_: MacroContext)
+fun hello(firClass: FirClass): MacroCompilation {
   return firClass.transform {
-    function {
-      //language=kotlin
-      """
-        fun hello(): String = "Hello"
-      """
-    }
+    //language=kotlin
+    """
+      fun hello(): String = "Hello"
+    """.function().create()
   }
 }
 
 @Macro(target = HelloClassTransform::class)
-fun MacroContext.world(firClass: FirClass): MacroCompilation {
+context(_: MacroContext)
+fun world(firClass: FirClass): MacroCompilation {
   return firClass.transform {
-    function {
-      //language=kotlin
-      """
-        fun world(): String = "World!"
-      """
-    }
+    //language=kotlin
+    """
+      fun world(): String = "World!"
+    """.function().create()
   }
 }

--- a/arrow-reflect-annotations/src/main/kotlin/arrow/meta/module/macro/increment.kt
+++ b/arrow-reflect-annotations/src/main/kotlin/arrow/meta/module/macro/increment.kt
@@ -4,6 +4,10 @@ import arrow.meta.module.impl.arrow.meta.macro.Macro
 import arrow.meta.module.impl.arrow.meta.macro.compilation.MacroCompilation
 import arrow.meta.module.impl.arrow.meta.macro.compilation.MacroContext
 import arrow.meta.module.impl.arrow.meta.macro.compilation.diagnosticError
+import arrow.meta.module.impl.arrow.meta.macro.compilation.diagnostics
+import arrow.meta.module.impl.arrow.meta.macro.compilation.report
+import arrow.meta.module.impl.arrow.meta.macro.compilation.transform
+import arrow.meta.module.impl.arrow.meta.macro.compilation.unaryPlus
 import arrow.meta.samples.Increment
 import org.jetbrains.kotlin.fir.expressions.FirCall
 import org.jetbrains.kotlin.fir.expressions.FirLiteralExpression
@@ -13,7 +17,8 @@ private val IncrementNotInConstantExpression by diagnosticError()
 private val IncrementNotInConstantInt by diagnosticError()
 
 @Macro(target = Increment::class)
-fun MacroContext.incrementChecker(statement: FirStatement): MacroCompilation {
+context(_: MacroContext)
+fun incrementChecker(statement: FirStatement): MacroCompilation {
   return diagnostics {
     when {
       statement !is FirLiteralExpression -> {
@@ -33,7 +38,8 @@ fun MacroContext.incrementChecker(statement: FirStatement): MacroCompilation {
 }
 
 @Macro(target = Increment::class)
-fun MacroContext.incrementTransformation(statement: FirStatement): MacroCompilation {
+context(_: MacroContext)
+fun incrementTransformation(statement: FirStatement): MacroCompilation {
   return transform {
     val exp = Kotlin { "${+statement} + 1" }
     exp.firstOrNull { it is FirCall } ?: statement

--- a/arrow-reflect-annotations/src/main/kotlin/arrow/meta/module/macro/log.kt
+++ b/arrow-reflect-annotations/src/main/kotlin/arrow/meta/module/macro/log.kt
@@ -5,6 +5,9 @@ import arrow.meta.module.impl.arrow.meta.macro.compilation.DiagnosticsContext
 import arrow.meta.module.impl.arrow.meta.macro.compilation.MacroCompilation
 import arrow.meta.module.impl.arrow.meta.macro.compilation.MacroContext
 import arrow.meta.module.impl.arrow.meta.macro.compilation.diagnosticError
+import arrow.meta.module.impl.arrow.meta.macro.compilation.diagnostics
+import arrow.meta.module.impl.arrow.meta.macro.compilation.report
+import arrow.meta.module.impl.arrow.meta.macro.compilation.unaryPlus
 import arrow.meta.samples.Log
 import org.jetbrains.kotlin.fir.FirElement
 import org.jetbrains.kotlin.fir.declarations.FirDeclaration
@@ -13,26 +16,23 @@ import org.jetbrains.kotlin.fir.expressions.FirExpression
 private val META_LOG by diagnosticError()
 
 @Macro(target = Log::class)
-fun MacroContext.log(declaration: FirDeclaration): MacroCompilation {
+context(_: MacroContext)
+fun log(declaration: FirDeclaration): MacroCompilation {
   return diagnostics {
-    checkElement(expression = declaration, diagnosticsContext = this)
+    declaration.report()
   }
 }
 
 @Macro(target = Log::class)
-fun MacroContext.log(expression: FirExpression): MacroCompilation {
+context(_: MacroContext)
+fun log(expression: FirExpression): MacroCompilation {
   return diagnostics {
-    checkElement(expression = expression, diagnosticsContext = this)
+    expression.report()
   }
 }
 
-private fun MacroContext.checkElement(
-  expression: FirElement,
-  diagnosticsContext: DiagnosticsContext
+context(_: MacroContext, _: DiagnosticsContext)
+private fun FirElement.report(
 ) {
-  with(diagnosticsContext) {
-    expression.report(
-      META_LOG, "found error on expression: ${+expression}"
-    )
-  }
+  report(META_LOG, "found error on expression: ${+this}")
 }

--- a/arrow-reflect-annotations/src/main/kotlin/arrow/meta/module/macro/log.kt
+++ b/arrow-reflect-annotations/src/main/kotlin/arrow/meta/module/macro/log.kt
@@ -32,7 +32,6 @@ fun log(expression: FirExpression): MacroCompilation {
 }
 
 context(_: MacroContext, _: DiagnosticsContext)
-private fun FirElement.report(
-) {
+private fun FirElement.report() {
   report(META_LOG, "found error on expression: ${+this}")
 }

--- a/arrow-reflect-annotations/src/main/kotlin/arrow/meta/module/macro/macro.kt
+++ b/arrow-reflect-annotations/src/main/kotlin/arrow/meta/module/macro/macro.kt
@@ -4,13 +4,16 @@ import arrow.meta.module.impl.arrow.meta.macro.Macro
 import arrow.meta.module.impl.arrow.meta.macro.compilation.MacroCompilation
 import arrow.meta.module.impl.arrow.meta.macro.compilation.MacroContext
 import arrow.meta.module.impl.arrow.meta.macro.compilation.diagnosticError
+import arrow.meta.module.impl.arrow.meta.macro.compilation.diagnostics
+import arrow.meta.module.impl.arrow.meta.macro.compilation.report
 import org.jetbrains.kotlin.fir.declarations.FirClass
 import org.jetbrains.kotlin.fir.declarations.utils.nameOrSpecialName
 
 private val MACRO_SAMPLE by diagnosticError()
 
 @Macro
-fun MacroContext.macro(firClass: FirClass): MacroCompilation {
+context(_: MacroContext)
+fun macro(firClass: FirClass): MacroCompilation {
   return diagnostics {
     if (firClass.nameOrSpecialName.identifier == "MacroSample") {
       firClass.report(MACRO_SAMPLE, "macro sample")

--- a/arrow-reflect-annotations/src/main/kotlin/arrow/meta/module/macro/product.kt
+++ b/arrow-reflect-annotations/src/main/kotlin/arrow/meta/module/macro/product.kt
@@ -3,19 +3,22 @@ package arrow.meta.module.impl.arrow.meta.module.macro
 import arrow.meta.module.impl.arrow.meta.macro.Macro
 import arrow.meta.module.impl.arrow.meta.macro.compilation.MacroCompilation
 import arrow.meta.module.impl.arrow.meta.macro.compilation.MacroContext
+import arrow.meta.module.impl.arrow.meta.macro.compilation.properties
+import arrow.meta.module.impl.arrow.meta.macro.compilation.transform
+import arrow.meta.module.impl.arrow.meta.macro.compilation.transformclassfactory.function
+import arrow.meta.module.impl.arrow.meta.macro.compilation.unaryPlus
 import arrow.meta.samples.Product
 import org.jetbrains.kotlin.fir.declarations.FirClass
 
 @Macro(target = Product::class)
-fun MacroContext.product(firClass: FirClass): MacroCompilation {
+context(_: MacroContext)
+fun product(firClass: FirClass): MacroCompilation {
   return firClass.transform {
-    function {
-      //language=kotlin
-      """
-        fun product(): List<Pair<String, *>> {               
-            return listOf(${propertiesOf(session, firClass) { """"${+it.name}" to this.${+it.name}""" }})
-        }
-      """
-    }
+    //language=kotlin
+    """
+      fun product(): List<Pair<String, *>> {               
+        return listOf(${firClass.properties { """"${+it.name}" to this.${+it.name}""" }})
+      }
+    """.function().create()
   }
 }

--- a/arrow-reflect-annotations/src/main/kotlin/arrow/meta/module/macro/property.kt
+++ b/arrow-reflect-annotations/src/main/kotlin/arrow/meta/module/macro/property.kt
@@ -1,0 +1,18 @@
+package arrow.meta.module.impl.arrow.meta.module.macro
+
+import arrow.meta.module.impl.arrow.meta.macro.Macro
+import arrow.meta.module.impl.arrow.meta.macro.compilation.MacroCompilation
+import arrow.meta.module.impl.arrow.meta.macro.compilation.MacroContext
+import arrow.meta.module.impl.arrow.meta.macro.compilation.transform
+import arrow.meta.module.impl.arrow.meta.macro.compilation.transformclassfactory.property
+import arrow.meta.samples.Property
+import org.jetbrains.kotlin.fir.declarations.FirClass
+
+@Macro(target = Property::class)
+context(_: MacroContext)
+fun property(firClass: FirClass): MacroCompilation {
+  return firClass.transform {
+    "val x: Int = 2".property().create()
+    "val y: Int = 3".property().create()
+  }
+}

--- a/arrow-reflect-annotations/src/main/kotlin/arrow/meta/module/macro/pure.kt
+++ b/arrow-reflect-annotations/src/main/kotlin/arrow/meta/module/macro/pure.kt
@@ -4,6 +4,8 @@ import arrow.meta.module.impl.arrow.meta.macro.Macro
 import arrow.meta.module.impl.arrow.meta.macro.compilation.MacroCompilation
 import arrow.meta.module.impl.arrow.meta.macro.compilation.MacroContext
 import arrow.meta.module.impl.arrow.meta.macro.compilation.diagnosticError
+import arrow.meta.module.impl.arrow.meta.macro.compilation.diagnostics
+import arrow.meta.module.impl.arrow.meta.macro.compilation.report
 import arrow.meta.samples.Pure
 import arrow.meta.samples.pure.createCallGraph
 import arrow.meta.samples.pure.render
@@ -20,7 +22,8 @@ private val restrictedNameSpaces = setOf(
 )
 
 @Macro(target = Pure::class)
-fun MacroContext.pure(function: FirSimpleFunction): MacroCompilation {
+context(_: MacroContext)
+fun pure(function: FirSimpleFunction): MacroCompilation {
   return diagnostics {
     val callGraph = createCallGraph(null, function)
     val unsafeCallsInGraph = callGraph.unsafeCalls(restrictedNameSpaces)

--- a/arrow-reflect-annotations/src/main/kotlin/arrow/meta/samples/Property.kt
+++ b/arrow-reflect-annotations/src/main/kotlin/arrow/meta/samples/Property.kt
@@ -1,0 +1,5 @@
+package arrow.meta.samples
+
+@Target(AnnotationTarget.CLASS)
+@Retention(AnnotationRetention.RUNTIME)
+annotation class Property

--- a/arrow-reflect-compiler-plugin/build.gradle.kts
+++ b/arrow-reflect-compiler-plugin/build.gradle.kts
@@ -61,8 +61,7 @@ dependencies {
 
 tasks.withType<KotlinCompile>().configureEach {
   compilerOptions {
-//    useK2.set(true)
-//    freeCompilerArgs.add("-Xcontext-receivers")
+    freeCompilerArgs.add("-Xcontext-parameters")
   }
 }
 

--- a/arrow-reflect-compiler-plugin/src/main/kotlin/arrow/reflect/compiler/plugin/fir/codegen/FirMacroCodegenExtension.kt
+++ b/arrow-reflect-compiler-plugin/src/main/kotlin/arrow/reflect/compiler/plugin/fir/codegen/FirMacroCodegenExtension.kt
@@ -2,6 +2,7 @@ package arrow.reflect.compiler.plugin.fir.codegen
 
 import arrow.meta.TemplateCompiler
 import arrow.meta.module.impl.arrow.meta.macro.compilation.*
+import arrow.meta.module.impl.arrow.meta.macro.compilation.transformclassfactory.TransformClassState
 import arrow.reflect.compiler.plugin.targets.macro.MacroInvoke
 import org.jetbrains.kotlin.GeneratedDeclarationKey
 import org.jetbrains.kotlin.config.CompilerConfiguration

--- a/arrow-reflect-compiler-plugin/src/main/kotlin/arrow/reflect/compiler/plugin/fir/codegen/FirMacroCodegenExtension.kt
+++ b/arrow-reflect-compiler-plugin/src/main/kotlin/arrow/reflect/compiler/plugin/fir/codegen/FirMacroCodegenExtension.kt
@@ -1,19 +1,23 @@
 package arrow.reflect.compiler.plugin.fir.codegen
 
 import arrow.meta.TemplateCompiler
-import arrow.meta.module.impl.arrow.meta.macro.compilation.*
+import arrow.meta.module.impl.arrow.meta.macro.compilation.MacroContext
+import arrow.meta.module.impl.arrow.meta.macro.compilation.TransformClassCompilation
+import arrow.meta.module.impl.arrow.meta.macro.compilation.TransformClassContext
 import arrow.meta.module.impl.arrow.meta.macro.compilation.transformclassfactory.TransformClassState
 import arrow.reflect.compiler.plugin.targets.macro.MacroInvoke
 import org.jetbrains.kotlin.GeneratedDeclarationKey
 import org.jetbrains.kotlin.config.CompilerConfiguration
 import org.jetbrains.kotlin.fir.FirAnnotationContainer
-import org.jetbrains.kotlin.fir.FirImplementationDetail
 import org.jetbrains.kotlin.fir.FirSession
+import org.jetbrains.kotlin.fir.declarations.utils.hasBackingField
 import org.jetbrains.kotlin.fir.extensions.FirDeclarationGenerationExtension
 import org.jetbrains.kotlin.fir.extensions.MemberGenerationContext
 import org.jetbrains.kotlin.fir.plugin.createMemberFunction
+import org.jetbrains.kotlin.fir.plugin.createMemberProperty
 import org.jetbrains.kotlin.fir.symbols.impl.FirClassSymbol
 import org.jetbrains.kotlin.fir.symbols.impl.FirNamedFunctionSymbol
+import org.jetbrains.kotlin.fir.symbols.impl.FirPropertySymbol
 import org.jetbrains.kotlin.fir.types.coneType
 import org.jetbrains.kotlin.name.CallableId
 import org.jetbrains.kotlin.name.Name
@@ -26,10 +30,30 @@ class FirMacroCodegenExtension(
 ) : FirDeclarationGenerationExtension(session) {
 
   class MacroGeneratedFunctionKey : GeneratedDeclarationKey()
+  class MacroGeneratedPropertyKey : GeneratedDeclarationKey()
 
   private val classFunctionStates: MutableMap<Name, MutableList<TransformClassState.Function>> = mutableMapOf()
+  private val classPropertyStates: MutableMap<Name, MutableList<TransformClassState.Property>> = mutableMapOf()
 
-  @OptIn(FirImplementationDetail::class)
+  override fun generateProperties(callableId: CallableId, context: MemberGenerationContext?): List<FirPropertySymbol> {
+    val owner = context?.owner ?: return emptyList()
+    val states = classPropertyStates[callableId.callableName] ?: return emptyList()
+    return states.map { property ->
+      val key = MacroGeneratedPropertyKey()
+      val firProperty = property.firProperty
+      macro.classTransformation()[key] = property
+      macro.bindIrActualizedResult(session = session, compilerConfiguration = compilerConfiguration)
+      createMemberProperty(
+        owner = owner,
+        key = key,
+        name = firProperty.name,
+        returnType = firProperty.returnTypeRef.coneType,
+        isVal = firProperty.isVal,
+        hasBackingField = firProperty.hasBackingField
+      ).symbol
+    }
+  }
+
   override fun generateFunctions(callableId: CallableId, context: MemberGenerationContext?): List<FirNamedFunctionSymbol> {
     val owner = context?.owner ?: return emptyList()
     val states = classFunctionStates[callableId.callableName] ?: return emptyList()
@@ -58,7 +82,7 @@ class FirMacroCodegenExtension(
     templateCompiler.compiling = true
     val fir = classSymbol.fir
     val annotations = (fir as? FirAnnotationContainer)?.annotations ?: emptyList()
-    val compilation = macro(
+    val states = macro(
       session,
       context = object : MacroContext {},
       element = fir,
@@ -68,8 +92,21 @@ class FirMacroCodegenExtension(
         session = session,
         scope = listOf()
       ))
+    }.flatMap { it.states() }
+    return states.classFunctionSymbols() + states.classPropertySymbols()
+  }
+
+  private fun List<TransformClassState>.classPropertySymbols(): Set<Name> {
+    val propertyStates = filterIsInstance<TransformClassState.Property>()
+    propertyStates.forEach { propertyState ->
+      val propertyName = propertyState.firProperty.name
+      classPropertyStates.getOrPut(propertyName) { mutableListOf() }.add(propertyState)
     }
-    val functionStates = compilation.flatMap { it.states() }.filterIsInstance<TransformClassState.Function>()
+    return propertyStates.map { it.firProperty.name }.toSet()
+  }
+
+  private fun List<TransformClassState>.classFunctionSymbols(): Set<Name> {
+    val functionStates = filterIsInstance<TransformClassState.Function>()
     functionStates.forEach { functionState ->
       val functionName = functionState.firSimpleFunction.name
       classFunctionStates.getOrPut(functionName) { mutableListOf() }.add(functionState)

--- a/arrow-reflect-compiler-plugin/src/main/kotlin/arrow/reflect/compiler/plugin/fir/transformers/FirMacroTransformer.kt
+++ b/arrow-reflect-compiler-plugin/src/main/kotlin/arrow/reflect/compiler/plugin/fir/transformers/FirMacroTransformer.kt
@@ -45,10 +45,6 @@ class FirMacroTransformer(
     return result ?: element
   }
 
-  override fun transformClass(klass: FirClass, data: FirDeclaration): FirStatement {
-    return super.transformClass(klass, data)
-  }
-
   override fun <E : FirElement> transformElement(element: E, data: FirDeclaration): E {
     element.transformChildren(this, data)
     return invokeMacro(element = element, scope = data)

--- a/arrow-reflect-compiler-plugin/src/main/kotlin/arrow/reflect/compiler/plugin/ir/IrArrowReflectExtension.kt
+++ b/arrow-reflect-compiler-plugin/src/main/kotlin/arrow/reflect/compiler/plugin/ir/IrArrowReflectExtension.kt
@@ -11,6 +11,6 @@ class IrArrowReflectExtension(
 ) : IrGenerationExtension {
 
   override fun generate(moduleFragment: IrModuleFragment, pluginContext: IrPluginContext) {
-    moduleFragment.acceptChildrenVoid(MacroIrFunctionTransformer(macro = macro))
+    moduleFragment.acceptChildrenVoid(MacroIrTransformer(macro = macro))
   }
 }

--- a/arrow-reflect-compiler-plugin/src/main/kotlin/arrow/reflect/compiler/plugin/ir/MacroIrTransformer.kt
+++ b/arrow-reflect-compiler-plugin/src/main/kotlin/arrow/reflect/compiler/plugin/ir/MacroIrTransformer.kt
@@ -5,14 +5,13 @@ import arrow.reflect.compiler.plugin.fir.codegen.FirMacroCodegenExtension
 import arrow.reflect.compiler.plugin.ir.generation.ArrowReflectFir2IrVisitor
 import arrow.reflect.compiler.plugin.ir.generation.toIr
 import arrow.reflect.compiler.plugin.targets.macro.MacroInvoke
-import org.jetbrains.kotlin.fir.declarations.DirectDeclarationsAccess
 import org.jetbrains.kotlin.fir.declarations.FirRegularClass
 import org.jetbrains.kotlin.ir.IrElement
 import org.jetbrains.kotlin.ir.declarations.*
 import org.jetbrains.kotlin.ir.visitors.IrVisitorVoid
 import org.jetbrains.kotlin.ir.visitors.acceptChildrenVoid
 
-class MacroIrFunctionTransformer(
+class MacroIrTransformer(
   private val macro: MacroInvoke
 ) : IrVisitorVoid() {
 
@@ -25,7 +24,15 @@ class MacroIrFunctionTransformer(
     }
   }
 
-  @OptIn(DirectDeclarationsAccess::class)
+  override fun visitProperty(declaration: IrProperty) {
+    val origin = declaration.origin as? IrDeclarationOrigin.GeneratedByPlugin ?: return
+    val key = origin.pluginKey as? FirMacroCodegenExtension.MacroGeneratedPropertyKey ?: return
+    val transformation = macro.classTransformation()[key] as? TransformClassState.Property ?: return
+    macro.irActualizedResult()?.run {
+      transformation.resolveProperty(original = declaration)
+    }
+  }
+
   override fun visitSimpleFunction(declaration: IrSimpleFunction) {
     val origin = declaration.origin as? IrDeclarationOrigin.GeneratedByPlugin ?: return
     val key = origin.pluginKey as? FirMacroCodegenExtension.MacroGeneratedFunctionKey ?: return
@@ -42,5 +49,14 @@ class MacroIrFunctionTransformer(
       firParent = context as FirRegularClass
     )
     original.body = function.body
+  }
+
+  context(_: ArrowReflectFir2IrVisitor)
+  private fun TransformClassState.Property.resolveProperty(original: IrProperty) {
+    val property = firProperty.toIr(
+      original = original,
+      firParent = context as FirRegularClass
+    )
+    original.backingField?.initializer = property.backingField?.initializer
   }
 }

--- a/arrow-reflect-compiler-plugin/src/main/kotlin/arrow/reflect/compiler/plugin/ir/generation/ArrowReflectFir2IrVisitor.kt
+++ b/arrow-reflect-compiler-plugin/src/main/kotlin/arrow/reflect/compiler/plugin/ir/generation/ArrowReflectFir2IrVisitor.kt
@@ -11,11 +11,18 @@ import org.jetbrains.kotlin.fir.FirSession
 import org.jetbrains.kotlin.fir.backend.*
 import org.jetbrains.kotlin.fir.backend.jvm.FirJvmVisibilityConverter
 import org.jetbrains.kotlin.fir.backend.jvm.JvmFir2IrExtensions
+import org.jetbrains.kotlin.fir.declarations.FirProperty
+import org.jetbrains.kotlin.fir.declarations.FirSimpleFunction
 import org.jetbrains.kotlin.fir.resolve.ScopeSession
 import org.jetbrains.kotlin.ir.backend.jvm.serialization.JvmIrMangler
+import org.jetbrains.kotlin.ir.declarations.IrClass
 import org.jetbrains.kotlin.ir.declarations.IrDeclarationParent
+import org.jetbrains.kotlin.ir.symbols.UnsafeDuringIrConstructionAPI
 import org.jetbrains.kotlin.ir.util.SymbolRemapper
+import org.jetbrains.kotlin.ir.util.functions
+import org.jetbrains.kotlin.ir.util.properties
 import org.jetbrains.kotlin.utils.getSafe
+import kotlin.sequences.forEach
 
 class ArrowReflectFir2IrVisitor private constructor(
   val visitor: Fir2IrVisitor,
@@ -67,4 +74,31 @@ class ArrowReflectFir2IrVisitor private constructor(
   }
 }
 
+@OptIn(UnsafeDuringIrConstructionAPI::class)
+context(visitor: ArrowReflectFir2IrVisitor)
+fun IrClass.cacheFunctions(
+  firFunctions: List<FirSimpleFunction>
+) {
+  functions.forEach { irFunction ->
+    firFunctions.firstOrNull {
+      it.name.identifier == irFunction.name.identifier
+    }?.let { function ->
+      visitor.storage.functionCache[function] = irFunction.symbol
+    }
+  }
+}
 
+@OptIn(UnsafeDuringIrConstructionAPI::class)
+context(visitor: ArrowReflectFir2IrVisitor)
+fun IrClass.cacheProperties(
+  firProperties: List<FirProperty>
+) {
+  properties.forEach { irProperty ->
+    firProperties.firstOrNull {
+      it.name.identifier == irProperty.name.identifier
+    }?.let { property ->
+      visitor.storage.propertyCache[property] = irProperty.symbol
+    }
+    irProperty.getter?.let { getter -> visitor.storage.getterForPropertyCache[irProperty.symbol] = getter.symbol }
+  }
+}

--- a/arrow-reflect-compiler-plugin/src/main/kotlin/arrow/reflect/compiler/plugin/ir/generation/IrPropertyGenerator.kt
+++ b/arrow-reflect-compiler-plugin/src/main/kotlin/arrow/reflect/compiler/plugin/ir/generation/IrPropertyGenerator.kt
@@ -5,19 +5,18 @@ import org.jetbrains.kotlin.fir.declarations.FirProperty
 import org.jetbrains.kotlin.fir.declarations.FirRegularClass
 import org.jetbrains.kotlin.fir.declarations.FirSimpleFunction
 import org.jetbrains.kotlin.ir.declarations.IrClass
-import org.jetbrains.kotlin.ir.declarations.IrSimpleFunction
-import org.jetbrains.kotlin.ir.symbols.IrSimpleFunctionSymbol
+import org.jetbrains.kotlin.ir.declarations.IrProperty
+import org.jetbrains.kotlin.ir.symbols.IrPropertySymbol
 import org.jetbrains.kotlin.ir.symbols.UnsafeDuringIrConstructionAPI
-import org.jetbrains.kotlin.ir.util.properties
 
 context(visitor: ArrowReflectFir2IrVisitor)
-fun FirSimpleFunction.toIr(
-  original: IrSimpleFunction,
+fun FirProperty.toIr(
+  original: IrProperty,
   firParent: FirRegularClass
-): IrSimpleFunction {
+): IrProperty {
   val parent = original.parent as? IrClass ?: return original
-  return visitor.resolveIrSimpleFunction(
-    function = this,
+  return visitor.resolveIrProperty(
+    firProperty = this,
     symbol = original.symbol,
     parent = parent,
     firParent = firParent
@@ -25,19 +24,20 @@ fun FirSimpleFunction.toIr(
 }
 
 @OptIn(DirectDeclarationsAccess::class, UnsafeDuringIrConstructionAPI::class)
-private fun ArrowReflectFir2IrVisitor.resolveIrSimpleFunction(
-  function: FirSimpleFunction,
-  symbol: IrSimpleFunctionSymbol,
+private fun ArrowReflectFir2IrVisitor.resolveIrProperty(
+  firProperty: FirProperty,
+  symbol: IrPropertySymbol,
   parent: IrClass,
   firParent: FirRegularClass
-): IrSimpleFunction {
+): IrProperty {
   val firProperties = firParent.declarations.filterIsInstance<FirProperty>()
   val firFunctions = firParent.declarations.filterIsInstance<FirSimpleFunction>()
   storage.classCache[firParent] = parent.symbol
-  storage.functionCache[function] = symbol
-  parent.cacheProperties(firProperties = firProperties)
+  storage.propertyCache[firProperty] = symbol
   parent.cacheFunctions(firFunctions = firFunctions)
+  parent.cacheProperties(firProperties = firProperties)
   return withParent(parent) {
-    visitor.visitSimpleFunction(simpleFunction = function, null) as IrSimpleFunction
+    visitor.visitProperty(firProperty, null) as IrProperty
   }
 }
+

--- a/arrow-reflect-compiler-plugin/src/main/kotlin/arrow/reflect/compiler/plugin/ir/generation/IrSimpleFunctionGenerator.kt
+++ b/arrow-reflect-compiler-plugin/src/main/kotlin/arrow/reflect/compiler/plugin/ir/generation/IrSimpleFunctionGenerator.kt
@@ -10,8 +10,22 @@ import org.jetbrains.kotlin.ir.symbols.IrSimpleFunctionSymbol
 import org.jetbrains.kotlin.ir.symbols.UnsafeDuringIrConstructionAPI
 import org.jetbrains.kotlin.ir.util.properties
 
+context(visitor: ArrowReflectFir2IrVisitor)
+fun FirSimpleFunction.toIr(
+  original: IrSimpleFunction,
+  firParent: FirRegularClass
+): IrSimpleFunction {
+  val parent = original.parent as? IrClass ?: return original
+  return visitor.resolveIrSimpleFunction(
+    function = this,
+    symbol = original.symbol,
+    parent = parent,
+    firParent = firParent
+  )
+}
+
 @OptIn(DirectDeclarationsAccess::class, UnsafeDuringIrConstructionAPI::class)
-fun ArrowReflectFir2IrVisitor.createIrFrom(
+private fun ArrowReflectFir2IrVisitor.resolveIrSimpleFunction(
   function: FirSimpleFunction,
   symbol: IrSimpleFunctionSymbol,
   parent: IrClass,
@@ -26,7 +40,7 @@ fun ArrowReflectFir2IrVisitor.createIrFrom(
     }?.let { property ->
       storage.propertyCache[property] = irProperty.symbol
     }
-    storage.getterForPropertyCache[irProperty.symbol] = irProperty.getter!!.symbol
+    irProperty.getter?.let { getter -> storage.getterForPropertyCache[irProperty.symbol] = getter.symbol }
   }
   return withParent(parent) {
     visitor.visitSimpleFunction(simpleFunction = function, null) as IrSimpleFunction

--- a/arrow-reflect-compiler-plugin/src/main/kotlin/arrow/reflect/compiler/plugin/targets/macro/MacroRegistry.kt
+++ b/arrow-reflect-compiler-plugin/src/main/kotlin/arrow/reflect/compiler/plugin/targets/macro/MacroRegistry.kt
@@ -2,7 +2,7 @@ package arrow.reflect.compiler.plugin.targets.macro
 
 import arrow.meta.module.impl.arrow.meta.macro.compilation.MacroCompilation
 import arrow.meta.module.impl.arrow.meta.macro.compilation.MacroContext
-import arrow.meta.module.impl.arrow.meta.macro.compilation.TransformClassState
+import arrow.meta.module.impl.arrow.meta.macro.compilation.transformclassfactory.TransformClassState
 import arrow.reflect.compiler.plugin.ir.generation.ArrowReflectFir2IrVisitor
 import org.jetbrains.kotlin.GeneratedDeclarationKey
 import org.jetbrains.kotlin.fir.FirElement

--- a/arrow-reflect-compiler-plugin/src/testData/transformation/property_test.fir.ir.txt
+++ b/arrow-reflect-compiler-plugin/src/testData/transformation/property_test.fir.ir.txt
@@ -1,0 +1,64 @@
+FILE fqName:foo.bar fileName:/module_main_property_test.kt
+  CLASS CLASS name:Sample modality:FINAL visibility:public superTypes:[kotlin.Any]
+    annotations:
+      Property
+    thisReceiver: VALUE_PARAMETER INSTANCE_RECEIVER kind:DispatchReceiver name:<this> type:foo.bar.Sample
+    PROPERTY GENERATED[arrow.reflect.compiler.plugin.fir.codegen.FirMacroCodegenExtension.MacroGeneratedPropertyKey] name:x visibility:public modality:FINAL [val]
+      FIELD PROPERTY_BACKING_FIELD name:x type:kotlin.Int visibility:private [final]
+        EXPRESSION_BODY
+          CONST Int type=kotlin.Int value=2
+      FUN DEFAULT_PROPERTY_ACCESSOR name:<get-x> visibility:public modality:FINAL returnType:kotlin.Int
+        VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:foo.bar.Sample
+        correspondingProperty: PROPERTY GENERATED[arrow.reflect.compiler.plugin.fir.codegen.FirMacroCodegenExtension.MacroGeneratedPropertyKey] name:x visibility:public modality:FINAL [val]
+        BLOCK_BODY
+          RETURN type=kotlin.Nothing from='public final fun <get-x> (): kotlin.Int declared in foo.bar.Sample'
+            GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:x type:kotlin.Int visibility:private [final]' type=kotlin.Int origin=null
+              receiver: GET_VAR '<this>: foo.bar.Sample declared in foo.bar.Sample.<get-x>' type=foo.bar.Sample origin=null
+    PROPERTY GENERATED[arrow.reflect.compiler.plugin.fir.codegen.FirMacroCodegenExtension.MacroGeneratedPropertyKey] name:y visibility:public modality:FINAL [val]
+      FIELD PROPERTY_BACKING_FIELD name:y type:kotlin.Int visibility:private [final]
+        EXPRESSION_BODY
+          CONST Int type=kotlin.Int value=3
+      FUN DEFAULT_PROPERTY_ACCESSOR name:<get-y> visibility:public modality:FINAL returnType:kotlin.Int
+        VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:foo.bar.Sample
+        correspondingProperty: PROPERTY GENERATED[arrow.reflect.compiler.plugin.fir.codegen.FirMacroCodegenExtension.MacroGeneratedPropertyKey] name:y visibility:public modality:FINAL [val]
+        BLOCK_BODY
+          RETURN type=kotlin.Nothing from='public final fun <get-y> (): kotlin.Int declared in foo.bar.Sample'
+            GET_FIELD 'FIELD PROPERTY_BACKING_FIELD name:y type:kotlin.Int visibility:private [final]' type=kotlin.Int origin=null
+              receiver: GET_VAR '<this>: foo.bar.Sample declared in foo.bar.Sample.<get-y>' type=foo.bar.Sample origin=null
+    CONSTRUCTOR visibility:public returnType:foo.bar.Sample [primary]
+      BLOCK_BODY
+        DELEGATING_CONSTRUCTOR_CALL 'public constructor <init> () declared in kotlin.Any'
+        INSTANCE_INITIALIZER_CALL classDescriptor='CLASS CLASS name:Sample modality:FINAL visibility:public superTypes:[kotlin.Any]' type=kotlin.Unit
+    FUN FAKE_OVERRIDE name:equals visibility:public modality:OPEN returnType:kotlin.Boolean [fake_override,operator]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+      VALUE_PARAMETER kind:Regular name:other index:1 type:kotlin.Any?
+      overridden:
+        public open fun equals (other: kotlin.Any?): kotlin.Boolean declared in kotlin.Any
+    FUN FAKE_OVERRIDE name:hashCode visibility:public modality:OPEN returnType:kotlin.Int [fake_override]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+      overridden:
+        public open fun hashCode (): kotlin.Int declared in kotlin.Any
+    FUN FAKE_OVERRIDE name:toString visibility:public modality:OPEN returnType:kotlin.String [fake_override]
+      VALUE_PARAMETER kind:DispatchReceiver name:<this> index:0 type:kotlin.Any
+      overridden:
+        public open fun toString (): kotlin.String declared in kotlin.Any
+  FUN name:box visibility:public modality:FINAL returnType:kotlin.String
+    BLOCK_BODY
+      VAR name:sample type:foo.bar.Sample [val]
+        CONSTRUCTOR_CALL 'public constructor <init> () declared in foo.bar.Sample' type=foo.bar.Sample origin=null
+      RETURN type=kotlin.Nothing from='public final fun box (): kotlin.String declared in foo.bar'
+        WHEN type=kotlin.String origin=IF
+          BRANCH
+            if: CALL 'public final fun EQEQ (arg0: kotlin.Any?, arg1: kotlin.Any?): kotlin.Boolean declared in kotlin.internal.ir' type=kotlin.Boolean origin=EQEQ
+              ARG arg0: CALL 'public final fun plus (other: kotlin.Int): kotlin.Int declared in kotlin.Int' type=kotlin.Int origin=PLUS
+                ARG <this>: CALL 'public final fun <get-x> (): kotlin.Int declared in foo.bar.Sample' type=kotlin.Int origin=GET_PROPERTY
+                  ARG <this>: GET_VAR 'val sample: foo.bar.Sample declared in foo.bar.box' type=foo.bar.Sample origin=null
+                ARG other: CALL 'public final fun <get-y> (): kotlin.Int declared in foo.bar.Sample' type=kotlin.Int origin=GET_PROPERTY
+                  ARG <this>: GET_VAR 'val sample: foo.bar.Sample declared in foo.bar.box' type=foo.bar.Sample origin=null
+              ARG arg1: CONST Int type=kotlin.Int value=5
+            then: BLOCK type=kotlin.String origin=null
+              CONST String type=kotlin.String value="OK"
+          BRANCH
+            if: CONST Boolean type=kotlin.Boolean value=true
+            then: BLOCK type=kotlin.String origin=null
+              CONST String type=kotlin.String value="Fail"

--- a/arrow-reflect-compiler-plugin/src/testData/transformation/property_test.fir.txt
+++ b/arrow-reflect-compiler-plugin/src/testData/transformation/property_test.fir.txt
@@ -1,0 +1,27 @@
+FILE: module_main_property_test.kt
+    package foo.bar
+
+    @R|arrow/meta/samples/Property|() public final class Sample : R|kotlin/Any| {
+        public constructor(): R|foo/bar/Sample| {
+            super<R|kotlin/Any|>()
+        }
+
+        public final val x: R|kotlin/Int|
+            public get(): R|kotlin/Int|
+
+        public final val y: R|kotlin/Int|
+            public get(): R|kotlin/Int|
+
+    }
+    public final fun box(): R|kotlin/String| {
+        lval sample: R|foo/bar/Sample| = R|foo/bar/Sample.Sample|()
+        ^box when () {
+            ==(R|<local>/sample|.R|foo/bar/Sample.x|.R|kotlin/Int.plus|(R|<local>/sample|.R|foo/bar/Sample.y|), Int(5)) ->  {
+                String(OK)
+            }
+            else ->  {
+                String(Fail)
+            }
+        }
+
+    }

--- a/arrow-reflect-compiler-plugin/src/testData/transformation/property_test.kt
+++ b/arrow-reflect-compiler-plugin/src/testData/transformation/property_test.kt
@@ -1,0 +1,17 @@
+// WITH_STDLIB
+// MODULE: main
+package foo.bar
+
+import arrow.meta.samples.Property
+
+@Property
+class Sample
+
+fun box(): String {
+  val sample = Sample()
+  return if (sample.x + sample.y == 5) {
+    "OK"
+  } else {
+    "Fail"
+  }
+}

--- a/arrow-reflect-compiler-plugin/src/testGenerated/arrow/reflect/compiler/plugin/runners/TransformationTestGenerated.java
+++ b/arrow-reflect-compiler-plugin/src/testGenerated/arrow/reflect/compiler/plugin/runners/TransformationTestGenerated.java
@@ -38,4 +38,10 @@ public class TransformationTestGenerated extends AbstractTransformationTest {
   public void testProduct_test() {
     runTest("src/testData/transformation/product_test.kt");
   }
+
+  @Test
+  @TestMetadata("property_test.kt")
+  public void testProperty_test() {
+    runTest("src/testData/transformation/property_test.kt");
+  }
 }


### PR DESCRIPTION
# What

This PR brings a design proposal using Kotlin `Context Parameters` feature to Macros API. The idea is to use the power of context parameter to build elegant and simple macro code, the proposals are:

### Context Parameter in Macro functions

Now developers can write macros using the benefits of context parameters:

```kotlin
@Macro(target = Product::class)
context(_: MacroContext)
fun product(firClass: FirClass): MacroCompilation {
  return firClass.transform {
    //language=kotlin
    """
      fun product(): List<Pair<String, *>> {               
        return listOf(${firClass.properties { """"${+it.name}" to this.${+it.name}""" }})
      }
    """.function().create()
  }
}
```

Some internal functions were also improved, for example `properties` that is a new version of `propertiesOf`, letting all macro construction more idiomatic and simple.

### Changes in `TransformClassCompilation`

The proposal in this compilation is to improve members construction in this compilation, so instead of:

```kotlin
firClass.transform {
  property {
    """
      val b = 2
    """
  }
  function {
    """
      fun a() {}
    """
  }
  function {
    """
      fun b() {}
    """
  }
}
```

This PR proposes:

```kotlin
firClass.transform {
  """
    val b = 2
  """.property().create()
  """
    fun a() {}
  """.function().create()
  """
    fun b() {}
  """.function().create()
}
```

I'm not totally against curly braces style but I feel it's more clear and simple if we try to let this class transformation scope linear. The idea to divide `create` function from `property` and `function` functions for example, is to separate its concerns letting `create` function type safe but let me know if you prefer another approach like `"val b = 2".createProperty()` and `"fun a() {}".createFunction`